### PR TITLE
pl-PL string too long

### DIFF
--- a/pl-PL/Localizable.strings
+++ b/pl-PL/Localizable.strings
@@ -488,7 +488,7 @@
 
 "dsk %lld" = "DÓŁ %lld";
 
-"dve" = "Efekt wideo (DVE)";
+"dve" = "Wideoefekt (DVE)";
 
 "dve-full" = "DVE Pełny ekran";
 
@@ -1552,7 +1552,7 @@
 
 "range" = "Zakres";
 
-"rate" = "Szybkość";
+"rate" = "Czas";
 
 "ratio" = "Stosunek";
 

--- a/pl-PL/Localizable.strings
+++ b/pl-PL/Localizable.strings
@@ -2246,3 +2246,7 @@
 
 "wipe-abbreviation" = "Wymaż";
 
+"next" = "Następny";
+
+"previous" = "Poprzedni";
+


### PR DESCRIPTION
some fixes for next version:
- some labels were too long to fit UI, hopefully now it will fit (we need to test it)
- Transition page uses long forms on buttons, and should use abbreviations (see screenshot)

![errors to fix](https://ze.psu.je/11Clms/note-24-may-2021.jpg)